### PR TITLE
docs(readme): fix "Creating the papi library" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This can be easily generated using the following commands:
 PRODUCT=SPM
 RULE_FORMAT=v2020-03-04
 mkdir -p jsonnet/lib/papi/${PRODUCT}
-akamai jsonnet papi --section papi schema --productId ${PRODUCT} --ruleFormat ${RULE_FORMAT} > jsonnet/lib/papi/SPM/${RULE_FORMAT}.libsonnet
+akamai jsonnet papi schema --productId ${PRODUCT} --ruleFormat ${RULE_FORMAT} > jsonnet/lib/papi/${PRODUCT}/${RULE_FORMAT}.libsonnet
 ```
 
 > SPM is the product id for Ion Premier. To see which products are available,


### PR DESCRIPTION
I was testing out this CLI and found an issue in the "Creating the `papi` library" example.  This pull request fixes the following issues I encountered:
1) `--section papi` if not an option for the `akamai jsonnet papi schema` command
2) product `SPM` hardcoded in output file path instead of using `$PRODUCT` env variable (I was using `Fresca`)