### PR TITLE
docs(readme): fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You will also need Akamai OPEN API credentials, please refer to the [Getting Sta
 ## Install
 
 ```
-akamai install akamai-contrib/cli-jsonnet.git
+akamai install akamai-contrib/cli-jsonnet
 ```
 
 ## Overview


### PR DESCRIPTION
Current:
```
$ akamai install akamai-contrib/cli-jsonnet.git
Attempting to fetch command from akamai-contrib/cli-jsonnet.git... ... [FAIL]
 ERROR[0000] Unable to clone repository: repository not found command=install
 ERROR[0000] INSTALL ERROR: Unable to clone repository: repository not found command=install
Unable to clone repository: repository not found
```

Fixed:
```
$ akamai install akamai-contrib/cli-jsonnet
Attempting to fetch command from https://github.com/akamai-contrib/cli-jsonnet.git... ... [OK]
Installing... ... [OK]

[...]
```

`akamai` CLI version:
```
$ akamai --version
akamai version 1.2.0
```